### PR TITLE
Add install script with flash-attn workaround

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,5 +1,12 @@
 # Installation Guide
 
+## Quick Setup
+Run the provided `install.sh` script to install all dependencies with the
+recommended `flash-attn` workaround:
+```bash
+bash install.sh
+```
+
 ## Install with pip
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -87,10 +87,9 @@ git clone https://github.com/JuanTaco4You/Wan2.1.git
 cd Wan2.1
 ```
 
-Install dependencies:
+Install dependencies (includes the `flash-attn` workaround):
 ```sh
-# Ensure torch >= 2.4.0
-pip install -r requirements.txt
+bash install.sh
 ```
 
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+
+# Simple install script applying the flash-attn workaround
+
+python -m pip install --upgrade pip setuptools wheel
+
+# Install flash-attn first, using the recommended no-build-isolation approach.
+if ! pip install flash-attn --no-build-isolation; then
+  # Fallback: install from Git if the wheel build still fails
+  pip install git+https://github.com/Dao-AILab/flash-attention.git
+fi
+
+# Install the rest of the dependencies
+pip install -r requirements.txt
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "ftfy",
     "dashscope",
     "imageio-ffmpeg",
-    "flash_attn",
+    "flash_attn @ git+https://github.com/Dao-AILab/flash-attention.git",
     "gradio>=5.0.0",
     "numpy>=1.23.5,<2"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,6 @@ easydict
 ftfy
 dashscope
 imageio-ffmpeg
-flash_attn
+flash_attn @ git+https://github.com/Dao-AILab/flash-attention.git
 gradio>=5.0.0
 numpy>=1.23.5,<2


### PR DESCRIPTION
## Summary
- add `install.sh` for easier installation including flash-attn workaround
- document new install script in README and INSTALL guides
- install flash-attn from Git by default in `requirements.txt` and `pyproject.toml`

## Testing
- `pytest -q`
- `shellcheck install.sh`


------
https://chatgpt.com/codex/tasks/task_e_6886e2f13a548325997cb8056766b5d5